### PR TITLE
fixed bug with existing directory while copying

### DIFF
--- a/utilities/edm_utils.py
+++ b/utilities/edm_utils.py
@@ -4,7 +4,8 @@ import os
 def copyDirLink(src, dst):
     # os.link(src, dst)
     try:
-        shutil.copytree(src, dst)
+    	if not os.path.exists(dst):    
+        	shutil.copytree(src, dst)
     except OSError as exc: # python >2.5
         if exc.errno == errno.ENOTDIR:
             shutil.copy(src, dst)


### PR DESCRIPTION
An error was being thrown if node_modules already existed in the domain_module folder. Fix to copy only if directory does not exist.